### PR TITLE
fix: /v1/token/validate open path + JWK public key support

### DIFF
--- a/packages/cloudflare-workers/src/index.tsx
+++ b/packages/cloudflare-workers/src/index.tsx
@@ -685,7 +685,7 @@ The link works for a limited time. Your human clicks it, gets a cookie, and sees
         'POST /v1/token/verify': 'Submit solution → access_token (1hr) + refresh_token (1hr) — app_id required',
         'POST /v1/token/refresh': 'Refresh access token — app_id required',
         'POST /v1/token/revoke': 'Revoke a token — app_id required',
-        'POST /v1/token/validate': 'Remote token validation — verify any BOTCHA token without needing the secret — app_id required',
+        'POST /v1/token/validate': 'Remote token validation — verify any BOTCHA token without needing the secret. Public endpoint — the token itself is the credential, no app_id required.',
       },
       protected: {
         'GET /agent-only': 'Demo protected endpoint — requires Bearer token (app_id required)',

--- a/packages/cloudflare-workers/src/tap-routes.ts
+++ b/packages/cloudflare-workers/src/tap-routes.ts
@@ -15,6 +15,7 @@ import {
   getTAPSession,
   updateAgentVerification,
   validateCapability,
+  isValidJWK,
   TAPCapability,
   TAP_VALID_ACTIONS
 } from './tap-agents.js';
@@ -100,27 +101,6 @@ async function validateAppAccess(c: Context, requireAuth: boolean = true): Promi
   }
 
   return { valid: true, appId: jwtAppId };
-}
-
-/**
- * Returns true if the string is a valid JWK JSON (EC or RSA public key).
- * Accepts both raw JWK JSON strings and serialized JWK objects.
- */
-function isValidJWK(key: string): boolean {
-  try {
-    const jwk = typeof key === 'string' ? JSON.parse(key) : key;
-    if (!jwk || typeof jwk !== 'object') return false;
-    if (!jwk.kty) return false;
-    // EC key: requires crv, x, y
-    if (jwk.kty === 'EC') return Boolean(jwk.crv && jwk.x && jwk.y);
-    // RSA key: requires n, e
-    if (jwk.kty === 'RSA') return Boolean(jwk.n && jwk.e);
-    // OKP (Ed25519): requires crv and x
-    if (jwk.kty === 'OKP') return Boolean(jwk.crv && jwk.x);
-    return false;
-  } catch {
-    return false;
-  }
 }
 
 function validateTAPRegistration(body: any): {

--- a/tests/unit/agents/tap-routes.test.ts
+++ b/tests/unit/agents/tap-routes.test.ts
@@ -4,7 +4,8 @@ import {
   getTAPAgentRoute,
   listTAPAgentsRoute,
   createTAPSessionRoute,
-  getTAPSessionRoute
+  getTAPSessionRoute,
+  rotateKeyRoute
 } from '../../../packages/cloudflare-workers/src/tap-routes.js';
 import type { TAPAgent } from '../../../packages/cloudflare-workers/src/tap-agents.js';
 import type { KVNamespace } from '../../../packages/cloudflare-workers/src/agents.js';
@@ -259,7 +260,7 @@ describe('TAP Routes - registerTAPAgentRoute', () => {
     expect(data.message).toContain('Invalid public key format');
   });
 
-  test('should accept JWK object as public_key', async () => {
+  test('should accept JWK object as public_key and store it as JSON string', async () => {
     const jwkPublic = {
       kty: 'EC',
       crv: 'P-256',
@@ -268,7 +269,9 @@ describe('TAP Routes - registerTAPAgentRoute', () => {
       use: 'sig',
       alg: 'ES256',
     };
+    const agentsKV = new MockKV();
     const mockContext = createMockContext({
+      agentsKV,
       query: vi.fn((key: string) => key === 'app_id' ? TEST_APP_ID : undefined),
       json: vi.fn().mockResolvedValue({
         name: 'JWK Agent',
@@ -284,6 +287,15 @@ describe('TAP Routes - registerTAPAgentRoute', () => {
     expect(data.success).toBe(true);
     expect(data.has_public_key).toBe(true);
     expect(data.tap_enabled).toBe(true);
+
+    // Verify the JWK object was serialized to a JSON string before storage
+    const storedRaw = agentsKV.getRaw(`agent:${data.agent_id}`);
+    expect(storedRaw).toBeDefined();
+    const storedAgent = JSON.parse(storedRaw!);
+    expect(typeof storedAgent.public_key).toBe('string');
+    const storedJwk = JSON.parse(storedAgent.public_key);
+    expect(storedJwk.kty).toBe('EC');
+    expect(storedJwk.crv).toBe('P-256');
   });
 
   test('should accept JWK JSON string as public_key', async () => {
@@ -1033,5 +1045,111 @@ describe('TAP Routes - getTAPSessionRoute', () => {
     expect(response.status).toBe(404);
     expect(data.success).toBe(false);
     expect(data.error).toBe('SESSION_NOT_FOUND');
+  });
+});
+
+describe('TAP Routes - rotateKeyRoute (JWK support)', () => {
+  const TEST_AGENT_ID = 'agent_rotatejwktest';
+
+  function seedAgent(agentsKV: MockKV, overrides: Partial<TAPAgent> = {}) {
+    const agent: TAPAgent = {
+      agent_id: TEST_AGENT_ID,
+      app_id: TEST_APP_ID,
+      name: 'Rotate Test Agent',
+      tap_enabled: true,
+      trust_level: 'basic',
+      capabilities: [],
+      public_key: '-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEold\n-----END PUBLIC KEY-----',
+      signature_algorithm: 'ecdsa-p256-sha256',
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      key_created_at: Date.now(),
+      ...overrides,
+    };
+    agentsKV.seed(`agent:${TEST_AGENT_ID}`, agent);
+    return agent;
+  }
+
+  test('should accept JWK object as new_public_key during rotation', async () => {
+    const agentsKV = new MockKV();
+    seedAgent(agentsKV);
+
+    const jwkPublic = {
+      kty: 'EC',
+      crv: 'P-256',
+      x: 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+      y: 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+    };
+
+    const mockContext = createMockContext({
+      agentsKV,
+      param: vi.fn((key: string) => key === 'id' ? TEST_AGENT_ID : undefined),
+      json: vi.fn().mockResolvedValue({
+        public_key: jwkPublic,
+        signature_algorithm: 'ecdsa-p256-sha256',
+      }),
+    });
+
+    const response = await rotateKeyRoute(mockContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.has_public_key).toBe(true);
+
+    // Verify JWK object was stored as JSON string
+    const storedRaw = agentsKV.getRaw(`agent:${TEST_AGENT_ID}`);
+    const storedAgent = JSON.parse(storedRaw!);
+    expect(typeof storedAgent.public_key).toBe('string');
+    const storedJwk = JSON.parse(storedAgent.public_key);
+    expect(storedJwk.kty).toBe('EC');
+  });
+
+  test('should accept JWK JSON string as new_public_key during rotation', async () => {
+    const agentsKV = new MockKV();
+    seedAgent(agentsKV);
+
+    const jwkJson = JSON.stringify({
+      kty: 'EC',
+      crv: 'P-256',
+      x: 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+      y: 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+    });
+
+    const mockContext = createMockContext({
+      agentsKV,
+      param: vi.fn((key: string) => key === 'id' ? TEST_AGENT_ID : undefined),
+      json: vi.fn().mockResolvedValue({
+        public_key: jwkJson,
+        signature_algorithm: 'ecdsa-p256-sha256',
+      }),
+    });
+
+    const response = await rotateKeyRoute(mockContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.has_public_key).toBe(true);
+  });
+
+  test('should return 400 for invalid key format during rotation', async () => {
+    const agentsKV = new MockKV();
+    seedAgent(agentsKV);
+
+    const mockContext = createMockContext({
+      agentsKV,
+      param: vi.fn((key: string) => key === 'id' ? TEST_AGENT_ID : undefined),
+      json: vi.fn().mockResolvedValue({
+        public_key: 'not-a-valid-key',
+        signature_algorithm: 'ecdsa-p256-sha256',
+      }),
+    });
+
+    const response = await rotateKeyRoute(mockContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('INVALID_KEY_FORMAT');
   });
 });


### PR DESCRIPTION
Found by live agent exploration of all BOTCHA endpoints.

## Bug 1: `POST /v1/token/validate` blocked by app middleware

The endpoint is designed for **public** token validation — the token itself is the credential, so third-party services shouldn't need to register an app just to verify a BOTCHA token. But it was missing from `APP_GATE_OPEN_PATHS`, causing a 401 for any caller without `app_id`.

**Fix:** Added `/v1/token/validate` to `APP_GATE_OPEN_PATHS`.

## Bug 2: TAP registration/rotation only accepts PEM keys

The rest of BOTCHA's infrastructure uses JWK everywhere (JWKS endpoint, `.well-known/jwks`, etc.), but `POST /v1/agents/register/tap` and `POST /v1/agents/:id/tap/rotate-key` only accepted PEM-encoded public keys. Sending a JWK object or JSON string returned 400 `Invalid public key format`.

**Fix:**
- Added `isValidJWK()` helper that validates EC, RSA, and OKP JWK structures
- Updated `validateTAPRegistration()` to auto-serialize JWK objects to JSON strings and accept JWK JSON
- Updated `rotateKeyRoute()` with same normalization + validation
- Updated `isValidPublicKey()` in `tap-agents.ts` to also recognize JWK JSON strings

All three key formats now accepted across the full TAP key lifecycle:
- PEM (`-----BEGIN PUBLIC KEY-----...`)
- JWK object (`{ kty: \EC\, crv: \P-256\, x: ..., y: ... }`)
- JWK JSON string

## Tests
- 2 new unit tests: JWK object registration, JWK JSON string registration
- All 38 existing tap-routes tests still pass