### PR TITLE
redesign: back to roots — minimal landing as homepage, showcase at /f…

### DIFF
--- a/packages/cloudflare-workers/src/dashboard/landing.tsx
+++ b/packages/cloudflare-workers/src/dashboard/landing.tsx
@@ -142,6 +142,17 @@ export const LandingPage: FC<{ version: string; error?: string }> = ({ version, 
         </details>
       </div>
 
+      {/* ---- Full stack link ---- */}
+      <div style="text-align: center; margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--border);">
+        <a
+          href="/features"
+          class="text-muted"
+          style="font-size: 0.6875rem; text-decoration: underline; text-underline-offset: 3px; letter-spacing: 0.05em;"
+        >
+          Full identity stack — TAP · DID/VC · A2A · OIDC-A · ANS · x402 →
+        </a>
+      </div>
+
       {/* ---- Embedded challenge (for crawling agents that parse HTML) ---- */}
       <script
         type="application/botcha+json"

--- a/packages/cloudflare-workers/src/index.tsx
+++ b/packages/cloudflare-workers/src/index.tsx
@@ -573,7 +573,7 @@ app.get('/', async (c) => {
     };
     const error = errorParam ? errorMessages[errorParam] || undefined : undefined;
 
-    return c.html(<ShowcasePage version={version} error={error} />);
+    return c.html(<LandingPage version={version} error={error} />);
   }
 
   // === UNVERIFIED: minimal teaser — just enough to get started ===
@@ -813,8 +813,13 @@ app.get('/og.png', (c) => {
 });
 
 // ============ SHOWCASE PAGE (legacy URL, redirect to home) ============
+app.get('/features', async (c) => {
+  const version = c.env.BOTCHA_VERSION || '0.16.0';
+  return c.html(<ShowcasePage version={version} />);
+});
+
 app.get('/showcase', (c) => {
-  return c.redirect('/', 301);
+  return c.redirect('/features', 301);
 });
 
 // ============ WHITEPAPER ============


### PR DESCRIPTION
…eatures

- GET / now serves the minimal LandingPage ('prove you're a bot') instead of ShowcasePage
- Full identity stack showcase moved to /features
- /showcase now 301 redirects to /features
- LandingPage gets a subtle 'Full identity stack →' footer link to /features
- Error messages (expired /go/ links) now show on the minimal landing, which already has the agent prompt

The front door is the hook. The depth is one click away.