### PR TITLE
fix(auth): add allowedTypes option to verifyToken; support agent-identity tokens

### DIFF
--- a/packages/cloudflare-workers/src/auth.ts
+++ b/packages/cloudflare-workers/src/auth.ts
@@ -32,11 +32,12 @@ export interface BotchaTokenPayload {
   iat: number // issued at
   exp: number // expires at
   jti: string // JWT ID for revocation
-  type: 'botcha-verified'
-  solveTime: number // how fast they solved it (ms)
+  type: 'botcha-verified' | 'botcha-agent-identity' | string
+  solveTime?: number // how fast they solved it (ms); optional for agent-identity tokens
   aud?: string // optional audience claim
   client_ip?: string // optional client IP binding
   app_id?: string // optional app ID (multi-tenant)
+  agent_id?: string // optional agent ID (agent-identity tokens)
 }
 
 /**
@@ -425,6 +426,7 @@ export async function verifyToken(
   options?: {
     requiredAud?: string // expected audience
     clientIp?: string // client IP to validate against
+    allowedTypes?: string[] // allowed token types (default: ['botcha-verified'])
   },
   publicKey?: {
     kty: string
@@ -456,8 +458,9 @@ export async function verifyToken(
       algorithms,
     })
 
-    // Check token type (must be access token, not refresh token)
-    if (payload.type !== 'botcha-verified') {
+    // Check token type (must be an allowed access token type)
+    const allowedTypes = options?.allowedTypes ?? ['botcha-verified']
+    if (!allowedTypes.includes(payload.type as string)) {
       return {
         valid: false,
         error: 'Invalid token type',
@@ -511,11 +514,12 @@ export async function verifyToken(
         iat: payload.iat || 0,
         exp: payload.exp || 0,
         jti: jti || '',
-        type: payload.type as 'botcha-verified',
-        solveTime: payload.solveTime as number,
+        type: payload.type as BotchaTokenPayload['type'],
+        solveTime: payload.solveTime as number | undefined,
         aud: payload.aud as string | undefined,
         client_ip: payload.client_ip as string | undefined,
         app_id: payload.app_id as string | undefined,
+        agent_id: payload.agent_id as string | undefined,
       },
     }
   } catch (error) {

--- a/packages/cloudflare-workers/src/index.tsx
+++ b/packages/cloudflare-workers/src/index.tsx
@@ -24,7 +24,7 @@ import {
   type KVNamespace,
 } from './challenges';
 import { SignJWT, jwtVerify } from 'jose';
-import { generateToken, verifyToken, extractBearerToken, revokeToken, refreshAccessToken, getSigningPublicKeyJWK, type ES256SigningKeyJWK } from './auth';
+import { generateToken, verifyToken, extractBearerToken, revokeToken, refreshAccessToken, getSigningPublicKeyJWK, type ES256SigningKeyJWK, type BotchaTokenPayload } from './auth';
 import { checkRateLimit, getClientIP } from './rate-limit';
 import { verifyBadge, generateBadgeSvg, generateBadgeHtml, createBadgeResponse } from './badge';
 import streamRoutes from './routes/stream';
@@ -165,13 +165,7 @@ type Bindings = {
 };
 
 type Variables = {
-  tokenPayload?: {
-    sub: string;
-    iat: number;
-    exp: number;
-    type: 'botcha-verified';
-    solveTime: number;
-  };
+  tokenPayload?: BotchaTokenPayload;
 };
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();

--- a/packages/cloudflare-workers/src/tap-oidca.ts
+++ b/packages/cloudflare-workers/src/tap-oidca.ts
@@ -13,7 +13,7 @@
  */
 
 import { SignJWT, jwtVerify, importJWK } from 'jose'
-import type { KVNamespace } from './auth.js'
+import type { KVNamespace, BotchaTokenPayload } from './auth.js'
 import type { ES256SigningKeyJWK } from './auth.js'
 import { getSigningPublicKeyJWK } from './auth.js'
 
@@ -238,16 +238,7 @@ function generateEATNonce(): string {
  * @returns Signed EAT JWT
  */
 export async function issueEAT(
-  botchaPayload: {
-    sub: string
-    iat: number
-    exp: number
-    jti: string
-    type: 'botcha-verified'
-    solveTime: number
-    app_id?: string
-    aud?: string
-  },
+  botchaPayload: BotchaTokenPayload,
   signingKey: ES256SigningKeyJWK,
   options?: {
     nonce?: string          // Client-provided nonce for freshness binding
@@ -284,7 +275,7 @@ export async function issueEAT(
     // BOTCHA private claims
     botcha_verified: true,
     botcha_challenge_id: botchaPayload.sub,
-    botcha_solve_time_ms: botchaPayload.solveTime,
+    botcha_solve_time_ms: botchaPayload.solveTime ?? 0,
     botcha_app_id: botchaPayload.app_id,
     botcha_verification_method: options?.verificationMethod ?? 'speed-challenge',
   }
@@ -316,16 +307,7 @@ export async function issueEAT(
  * @returns Signed OIDC-A claims JWT + plain claims object
  */
 export async function buildOIDCAgentClaims(
-  botchaPayload: {
-    sub: string
-    iat: number
-    exp: number
-    jti: string
-    type: 'botcha-verified'
-    solveTime: number
-    app_id?: string
-    aud?: string
-  },
+  botchaPayload: BotchaTokenPayload,
   eatToken: string,
   signingKey: ES256SigningKeyJWK,
   options?: {
@@ -376,7 +358,7 @@ export async function buildOIDCAgentClaims(
     // Verification metadata — reflect the actual challenge type used
     agent_verification: {
       method: `botcha-${verificationMethod}`,
-      solve_time_ms: botchaPayload.solveTime,
+      solve_time_ms: botchaPayload.solveTime ?? 0,
       verified_at: new Date(botchaPayload.iat * 1000).toISOString(),
       issuer: BOTCHA_ISSUER,
       challenge_id: botchaPayload.sub,
@@ -432,15 +414,7 @@ export async function buildOIDCAgentClaims(
  * @returns AgentGrantResult
  */
 export async function issueAgentGrant(
-  botchaPayload: {
-    sub: string
-    iat: number
-    exp: number
-    jti: string
-    type: 'botcha-verified'
-    solveTime: number
-    app_id?: string
-  },
+  botchaPayload: BotchaTokenPayload,
   eatToken: string,
   oidcClaims: OIDCAgentClaims,
   signingKey: ES256SigningKeyJWK,


### PR DESCRIPTION
## Problem

CI has been red since Monday due to 6 failing tests in `agent-identity-token-auth.test.ts`. The tests correctly validate that `verifyToken()` should accept `botcha-agent-identity` tokens when an `allowedTypes` option is passed — but the implementation never supported this option.

## Root Cause

`verifyToken()` hardcoded `payload.type !== 'botcha-verified'` with no way to override. Additionally:
- `BotchaTokenPayload` type had `type: 'botcha-verified'` as a literal (not accepting other types)
- No `agent_id` field in `BotchaTokenPayload` or in the return payload
- `issueEAT`, `buildOIDCAgentClaims`, `issueAgentGrant` in `tap-oidca.ts` duplicated inline type structs instead of using `BotchaTokenPayload`

## Fix

- Add `allowedTypes?: string[]` option to `verifyToken()` (defaults to `['botcha-verified']` — no behavior change for existing callers)
- Widen `BotchaTokenPayload.type` to `'botcha-verified' | 'botcha-agent-identity' | string`
- Add `agent_id?: string` field to `BotchaTokenPayload` and include it in the return value
- Make `solveTime` optional (agent-identity tokens don't have a solve time)
- Update `Variables.tokenPayload` in `index.tsx` to use `BotchaTokenPayload` directly
- Refactor `tap-oidca.ts` functions to use `BotchaTokenPayload` instead of duplicated inline type defs

## Tests

```
Test Files: 35 passed (previously 34 — agent-identity-token-auth.test.ts now passing)
Tests: 1006 passed, 0 failed (previously 6 failing)
```

All existing tests continue to pass. No behavior change for `botcha-verified` flows.