### PR TITLE
feat: add CJS (CommonJS) support via dual ESM/CJS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           cd packages/cloudflare-workers
           bun run build
 
+      - name: Verify CJS output
+        run: node scripts/verify-cjs.cjs
+
       - name: Run TypeScript tests
         run: bun run test
 

--- a/package.json
+++ b/package.json
@@ -5,31 +5,36 @@
   "workspaces": [
     "packages/*"
   ],
-  "main": "dist/lib/index.js",
+  "main": "dist/cjs/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/lib/index.js",
-      "types": "./dist/lib/index.d.ts"
+      "types": "./dist/lib/index.d.ts",
+      "require": "./dist/cjs/lib/index.js",
+      "import": "./dist/lib/index.js"
     },
     "./client": {
-      "import": "./dist/lib/client/index.js",
-      "types": "./dist/lib/client/index.d.ts"
+      "types": "./dist/lib/client/index.d.ts",
+      "require": "./dist/cjs/lib/client/index.js",
+      "import": "./dist/lib/client/index.js"
     },
     "./middleware": {
-      "import": "./dist/src/middleware/tap-enhanced-verify.js",
-      "types": "./dist/src/middleware/tap-enhanced-verify.d.ts"
+      "types": "./dist/src/middleware/tap-enhanced-verify.d.ts",
+      "require": "./dist/cjs/src/middleware/tap-enhanced-verify.js",
+      "import": "./dist/src/middleware/tap-enhanced-verify.js"
     }
   },
   "files": [
     "dist/lib",
+    "dist/cjs",
     "dist/src",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'},null,2))\"",
+    "test:cjs": "node scripts/verify-cjs.cjs",
     "dev": "cd packages/cloudflare-workers && bun run dev",
     "prepublishOnly": "bun run build",
     "test": "vitest",

--- a/scripts/verify-cjs.cjs
+++ b/scripts/verify-cjs.cjs
@@ -64,4 +64,5 @@ if (failed > 0) {
   process.exit(1);
 } else {
   console.log('\nAll CJS checks passed ✓\n');
+  process.exit(0);
 }

--- a/scripts/verify-cjs.cjs
+++ b/scripts/verify-cjs.cjs
@@ -1,0 +1,67 @@
+/**
+ * CJS Compatibility Verification Script
+ * Run after `bun run build` to verify the CJS output works.
+ * Usage: node scripts/verify-cjs.cjs
+ */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const ROOT = path.resolve(__dirname, '..');
+
+let failed = 0;
+
+function check(label, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${label}`);
+  } catch (err) {
+    console.error(`  ✗ ${label}: ${err.message}`);
+    failed++;
+  }
+}
+
+console.log('\nVerifying CJS output...\n');
+
+// 1. Files exist
+check('dist/cjs/package.json marks type=commonjs', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'dist/cjs/package.json'), 'utf8'));
+  if (pkg.type !== 'commonjs') throw new Error(`Expected "commonjs", got "${pkg.type}"`);
+});
+
+check('dist/cjs/lib/index.js exists', () => {
+  if (!fs.existsSync(path.join(ROOT, 'dist/cjs/lib/index.js'))) throw new Error('Missing');
+});
+
+check('dist/cjs/lib/client/index.js exists', () => {
+  if (!fs.existsSync(path.join(ROOT, 'dist/cjs/lib/client/index.js'))) throw new Error('Missing');
+});
+
+check('dist/cjs/src/middleware/tap-enhanced-verify.js exists', () => {
+  if (!fs.existsSync(path.join(ROOT, 'dist/cjs/src/middleware/tap-enhanced-verify.js'))) throw new Error('Missing');
+});
+
+// 2. require() works
+check('require("./dist/cjs/lib/index.js") exports botcha + verify + solve', () => {
+  const mod = require(path.join(ROOT, 'dist/cjs/lib/index.js'));
+  if (typeof mod.botcha !== 'object') throw new Error(`botcha not exported (got ${typeof mod.botcha})`);
+  if (typeof mod.verify !== 'function') throw new Error(`verify not exported (got ${typeof mod.verify})`);
+  if (typeof mod.solve !== 'function') throw new Error(`solve not exported (got ${typeof mod.solve})`);
+});
+
+check('require("./dist/cjs/lib/client/index.js") loads without error', () => {
+  const mod = require(path.join(ROOT, 'dist/cjs/lib/client/index.js'));
+  if (Object.keys(mod).length === 0) throw new Error('No exports');
+});
+
+check('require("./dist/cjs/src/middleware/tap-enhanced-verify.js") loads without error', () => {
+  const mod = require(path.join(ROOT, 'dist/cjs/src/middleware/tap-enhanced-verify.js'));
+  if (Object.keys(mod).length === 0) throw new Error('No exports');
+});
+
+if (failed > 0) {
+  console.error(`\n${failed} check(s) failed.\n`);
+  process.exit(1);
+} else {
+  console.log('\nAll CJS checks passed ✓\n');
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist/cjs",
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -4,7 +4,7 @@
     "module": "CommonJS",
     "moduleResolution": "Node",
     "outDir": "./dist/cjs",
-    "declaration": true,
-    "declarationMap": true
+    "declaration": false,
+    "declarationMap": false
   }
 }


### PR DESCRIPTION
Closes #37

## What

Adds CommonJS support so the package works in CJS projects with `require()`.

## How

- **Dual build**: `bun run build` now compiles both ESM (`dist/lib/`) and CJS (`dist/cjs/`) via a new `tsconfig.cjs.json`
- **exports map**: Updated with `require` conditions for all 3 entry points (`.`, `./client`, `./middleware`)
- **`dist/cjs/package.json`**: Written at build time with `{ "type": "commonjs" }` so Node.js treats `.js` files there correctly — no need to rename to `.cjs`
- **`main` field**: Now points to CJS entry for legacy tools that ignore `exports`
- **`scripts/verify-cjs.cjs`**: Standalone verification script — CI runs it after build

## Usage

```js
// CJS
const { botcha, verify, solve } = require("@dupecom/botcha");
const { BotchaStreamClient } = require("@dupecom/botcha/client");

// ESM (unchanged)
import { botcha, verify, solve } from "@dupecom/botcha";
```

## CI

Added "Verify CJS output" step after build. Also fixes the `types` condition ordering in exports (must come before `require`/`import` per bundler spec).