### PR TITLE
fix(token-validate): accept all BOTCHA token types in POST /v1/token/validate (+3 TAP UX bugs)

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,6 +1,6 @@
 # BOTCHA — Active Issues Tracker
 
-*Last updated: 2026-04-13 by Choco*
+*Last updated: 2026-04-20 by Choco*
 
 ---
 
@@ -26,23 +26,28 @@ Full OIDC-A attestation endpoint — EAT tokens, agent grants, OAuth AS metadata
 ### PR #26 — A2A Agent Card (MERGED)
 A2A trust oracle with agent cards. Merged.
 
+### PR #41 — TAP UX Improvements (MERGED v0.24.0)
+**Bugs fixed:** agents/me 404 fix, INVALID_TTL validation, time_remaining_seconds, ACTION_CATEGORY_MISMATCH hint, reputation alias route.
+
+### Issue #37 / PR #40 — CJS Support (MERGED v0.24.0)
+Dual ESM/CJS build via tsconfig.cjs.json + verify-cjs.cjs CI check.
+
 ---
 
 ## 🔄 IN PROGRESS
 
-### PR #41 — TAP UX Improvements (open, needs BOTCHA verify + CI)
-**URL:** https://github.com/dupe-com/botcha/pull/41
-**Bugs fixed (all confirmed on live API 2026-04-13):**
-1. `GET /v1/agents/me` → 404 (now resolves from Bearer token)
-2. `ttl_seconds: -100` on `POST /v1/sessions/tap` → silently accepted (now 400 INVALID_TTL)
-3. `GET /v1/sessions/:id/tap` returns `time_remaining` in ms (renamed to `time_remaining_seconds`, now integer seconds)
-4. `ACTION_CATEGORY_MISMATCH` error gives no hint about valid actions (now includes `valid_actions` array)
-5. `GET /v1/agents/:id/reputation` → 404 (alias route added, must come before generic `:id`)
+### PR — Three TAP UX bugs (2026-04-20 sprint, Choco)
+**Branch:** `fix/agent-me-reputation-delegation-ux`
+**Bugs confirmed on live API 2026-04-20:**
 
-### Issue #37 — CJS Support
-**URL:** https://github.com/dupe-com/botcha/issues/37
-**PRs:** #39 (Copilot, uses tsup), #40 (chocothebot, uses tsc + tsconfig.cjs.json)
-**Recommendation:** Merge PR #39 — more comprehensive, covers langchain + verify packages, uses tsup for better bundler compatibility. Supersedes #40.
+1. **`GET /v1/agents/me` rejects agent-identity tokens** — `verifyToken` called with `undefined` options (defaults to `botcha-verified` only). OAuth-refresh tokens are blocked even though they ARE valid agent-identity tokens.
+   - **Fix:** Pass `{ allowedTypes: ['botcha-verified', 'botcha-agent-identity'] }` (same pattern as all TAP routes)
+
+2. **`GET /v1/agents/:id/reputation` → 400 MISSING_AGENT_ID** — Alias route registered with `:id` param but `getReputationRoute` reads `c.req.param('agent_id')`.
+   - **Fix:** Try `c.req.param('agent_id') || c.req.param('id')` in handler
+
+3. **`POST /v1/delegations` — string capabilities give misleading error** — Passing `["browse", "search"]` returns "Invalid capability action. Valid: browse, compare, purchase, audit, search" — implying the value is wrong when the actual issue is the format.
+   - **Fix:** Normalize strings to `{action: string}` objects before validation; clearer error message naming the bad action and accepted formats
 
 ---
 

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,6 +1,6 @@
 # BOTCHA — Active Issues Tracker
 
-*Last updated: 2026-04-20 by Choco*
+*Last updated: 2026-04-27 by Choco*
 
 ---
 
@@ -36,18 +36,25 @@ Dual ESM/CJS build via tsconfig.cjs.json + verify-cjs.cjs CI check.
 
 ## 🔄 IN PROGRESS
 
-### PR — Three TAP UX bugs (2026-04-20 sprint, Choco)
-**Branch:** `fix/agent-me-reputation-delegation-ux`
-**Bugs confirmed on live API 2026-04-20:**
+### PR — Four UX/correctness bugs (2026-04-27 sprint, Choco)
+**Branch:** `fix/token-validate-all-types`
+**Bugs confirmed on live API:**
 
-1. **`GET /v1/agents/me` rejects agent-identity tokens** — `verifyToken` called with `undefined` options (defaults to `botcha-verified` only). OAuth-refresh tokens are blocked even though they ARE valid agent-identity tokens.
-   - **Fix:** Pass `{ allowedTypes: ['botcha-verified', 'botcha-agent-identity'] }` (same pattern as all TAP routes)
+**Bug 1 (2026-04-20): `GET /v1/agents/me` rejects agent-identity tokens**
+`verifyToken` called with `undefined` options (defaults to `botcha-verified` only). OAuth-refresh tokens are blocked on the one route designed specifically to help agents identify themselves.
+- **Fix:** Pass `{ allowedTypes: ['botcha-verified', 'botcha-agent-identity'] }`
 
-2. **`GET /v1/agents/:id/reputation` → 400 MISSING_AGENT_ID** — Alias route registered with `:id` param but `getReputationRoute` reads `c.req.param('agent_id')`.
-   - **Fix:** Try `c.req.param('agent_id') || c.req.param('id')` in handler
+**Bug 2 (2026-04-20): `GET /v1/agents/:id/reputation` → 400 MISSING_AGENT_ID**
+Alias route registered with `:id` param but `getReputationRoute` reads `c.req.param('agent_id')` — always undefined via this alias.
+- **Fix:** Try `c.req.param('agent_id') || c.req.param('id')` in handler
 
-3. **`POST /v1/delegations` — string capabilities give misleading error** — Passing `["browse", "search"]` returns "Invalid capability action. Valid: browse, compare, purchase, audit, search" — implying the value is wrong when the actual issue is the format.
-   - **Fix:** Normalize strings to `{action: string}` objects before validation; clearer error message naming the bad action and accepted formats
+**Bug 3 (2026-04-20): `POST /v1/delegations` — string capabilities give misleading error**
+Passing `["browse", "search"]` returns "Invalid capability action. Valid: browse…" — implying the value is wrong when the actual issue is the format (`{action: "browse"}` required).
+- **Fix:** Normalize strings to `{action: string}` objects before validation; clearer error message
+
+**Bug 4 (2026-04-27): `POST /v1/token/validate` rejects attestation and agent-identity tokens**
+The public validation endpoint is documented as "verify any BOTCHA token" but calls `verifyToken` with `undefined` options — defaulting to `allowedTypes: ['botcha-verified']`. Any non-challenge token (agent-identity, attestation, ANS badge, VC) gets `{"valid": false, "error": "Invalid token type"}`.
+- **Fix:** Export `ALL_BOTCHA_ACCESS_TOKEN_TYPES` constant from `auth.ts`; pass it as `allowedTypes` to the validate endpoint. Refresh tokens intentionally excluded.
 
 ---
 
@@ -78,6 +85,10 @@ Dual ESM/CJS build via tsconfig.cjs.json + verify-cjs.cjs CI check.
 
 ### 5. Delegation field naming inconsistency (docs vs API)
 **Location:** `POST /v1/delegations`
-**Issue:** Natural field names are `delegator_agent_id`/`delegate_agent_id` but API uses `grantor_id`/`grantee_id`. AI agents consistently use the wrong names (tested 2026-04-13).
+**Issue:** Natural field names are `delegator_agent_id`/`delegate_agent_id` but API uses `grantor_id`/`grantee_id`. AI agents consistently use the wrong names (tested 2026-04-13 and 2026-04-27).
 **Fix:** Accept both field names (alias) or update docs/OpenAPI to be clearer
 **Priority:** 🟡 MINOR — docs confusion
+
+### 6. No session listing endpoint
+**Issue:** Agents cannot list their own active sessions (e.g., `GET /v1/sessions?agent_id=...`). Must manually track session IDs.
+**Priority:** 🟡 MINOR — convenience feature, not a correctness bug

--- a/packages/cloudflare-workers/src/auth.ts
+++ b/packages/cloudflare-workers/src/auth.ts
@@ -531,6 +531,20 @@ export async function verifyToken(
 }
 
 /**
+ * All known BOTCHA token types.
+ * Used by the public /v1/token/validate endpoint to accept any BOTCHA-issued token.
+ * Note: refresh tokens (botcha-refresh) are intentionally excluded — they are
+ * bearer credentials and should not be validated by third parties.
+ */
+export const ALL_BOTCHA_ACCESS_TOKEN_TYPES = [
+  'botcha-verified',          // Standard challenge-pass token
+  'botcha-agent-identity',    // Agent OAuth / refresh-flow identity token
+  'botcha-attestation',       // TAP capability attestation token
+  'botcha-ans-badge',         // ANS badge token
+  'botcha-vc',                // W3C Verifiable Credential token
+] as const;
+
+/**
  * Extract Bearer token from Authorization header
  */
 export function extractBearerToken(authHeader?: string): string | null {

--- a/packages/cloudflare-workers/src/index.tsx
+++ b/packages/cloudflare-workers/src/index.tsx
@@ -24,7 +24,7 @@ import {
   type KVNamespace,
 } from './challenges';
 import { SignJWT, jwtVerify } from 'jose';
-import { generateToken, verifyToken, extractBearerToken, revokeToken, refreshAccessToken, getSigningPublicKeyJWK, type ES256SigningKeyJWK, type BotchaTokenPayload } from './auth';
+import { generateToken, verifyToken, extractBearerToken, revokeToken, refreshAccessToken, getSigningPublicKeyJWK, ALL_BOTCHA_ACCESS_TOKEN_TYPES, type ES256SigningKeyJWK, type BotchaTokenPayload } from './auth';
 import { checkRateLimit, getClientIP } from './rate-limit';
 import { verifyBadge, generateBadgeSvg, generateBadgeHtml, createBadgeResponse } from './badge';
 import streamRoutes from './routes/stream';
@@ -1631,7 +1631,12 @@ app.post('/v1/token/validate', async (c) => {
   }
 
   const validatePublicKey = getPublicKey(c.env);
-  const result = await verifyToken(token, c.env.JWT_SECRET, c.env, undefined, validatePublicKey);
+  // Accept all BOTCHA access token types — this is a public validation endpoint.
+  // Refresh tokens (botcha-refresh) are excluded: they are bearer credentials
+  // and must never be exposed to third-party validators.
+  const result = await verifyToken(token, c.env.JWT_SECRET, c.env, {
+    allowedTypes: [...ALL_BOTCHA_ACCESS_TOKEN_TYPES],
+  }, validatePublicKey);
 
   if (!result.valid) {
     return c.json({

--- a/packages/cloudflare-workers/src/index.tsx
+++ b/packages/cloudflare-workers/src/index.tsx
@@ -2749,12 +2749,13 @@ app.get('/v1/agents/:id', async (c) => {
         }, 401);
       }
       const publicKey = getPublicKey(c.env);
-      const verification = await verifyToken(bearerToken, c.env.JWT_SECRET, c.env, undefined, publicKey);
+      // Accept both challenge-verified tokens and agent-identity tokens (from OAuth refresh flow)
+      const verification = await verifyToken(bearerToken, c.env.JWT_SECRET, c.env, { allowedTypes: ['botcha-verified', 'botcha-agent-identity'] }, publicKey);
       if (!verification.valid || !verification.payload?.agent_id) {
         return c.json({
           success: false,
           error: 'UNAUTHORIZED',
-          message: 'Invalid or expired token — must be an agent-identity token to use /v1/agents/me',
+          message: 'Invalid or expired token — must be a botcha-verified or agent-identity token to use /v1/agents/me',
         }, 401);
       }
       agent_id = verification.payload.agent_id;

--- a/packages/cloudflare-workers/src/tap-delegation-routes.ts
+++ b/packages/cloudflare-workers/src/tap-delegation-routes.ts
@@ -61,13 +61,19 @@ export async function createDelegationRoute(c: Context) {
       }, 400);
     }
 
+    // Normalize: accept plain strings like ["browse", "search"] as well as objects [{action:"browse"}]
+    const normalizedCapabilities = body.capabilities.map((cap: any) =>
+      typeof cap === 'string' ? { action: cap } : cap
+    );
+
     // Validate capability actions
-    for (const cap of body.capabilities) {
+    for (const cap of normalizedCapabilities) {
       if (!cap.action || !(TAP_VALID_ACTIONS as readonly string[]).includes(cap.action)) {
         return c.json({
           success: false,
           error: 'INVALID_CAPABILITY',
-          message: `Invalid capability action. Valid: ${TAP_VALID_ACTIONS.join(', ')}`
+          message: `Invalid capability action "${cap.action}". Valid actions: ${TAP_VALID_ACTIONS.join(', ')}. ` +
+            `Capabilities must be objects like {"action":"browse"} or plain strings like "browse".`
         }, 400);
       }
     }
@@ -75,7 +81,7 @@ export async function createDelegationRoute(c: Context) {
     const options: CreateDelegationOptions = {
       grantor_id: body.grantor_id,
       grantee_id: body.grantee_id,
-      capabilities: body.capabilities,
+      capabilities: normalizedCapabilities,
       duration_seconds: body.duration_seconds,
       max_depth: body.max_depth,
       parent_delegation_id: body.parent_delegation_id,

--- a/packages/cloudflare-workers/src/tap-reputation-routes.ts
+++ b/packages/cloudflare-workers/src/tap-reputation-routes.ts
@@ -35,7 +35,8 @@ import {
  */
 export async function getReputationRoute(c: Context) {
   try {
-    const agentId = c.req.param('agent_id');
+    // Support both :agent_id (primary route) and :id (alias route /v1/agents/:id/reputation)
+    const agentId = c.req.param('agent_id') || c.req.param('id');
     if (!agentId) {
       return c.json({
         success: false,

--- a/tests/unit/agents/fix-ux-bugs-2026-04-20.test.ts
+++ b/tests/unit/agents/fix-ux-bugs-2026-04-20.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Regression tests for UX bugs found during weekly inspection sprint (2026-04-20).
+ *
+ * Bug 1: GET /v1/agents/me rejected agent-identity tokens
+ *   - verifyToken called with undefined options (defaulted to botcha-verified only)
+ *   - Fix: pass { allowedTypes: ['botcha-verified', 'botcha-agent-identity'] }
+ *
+ * Bug 2: GET /v1/agents/:id/reputation alias route returned MISSING_AGENT_ID
+ *   - getReputationRoute reads c.req.param('agent_id') but alias route uses :id param
+ *   - Fix: try both c.req.param('agent_id') and c.req.param('id')
+ *
+ * Bug 3: POST /v1/delegations — string capabilities gave misleading error
+ *   - Passing ["browse", "search"] returned "Invalid capability action. Valid: browse..."
+ *   - Actual issue: capabilities must be [{action:"browse"}] objects, not plain strings
+ *   - Fix: normalize string → {action: string} before validation; clearer error message
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { SignJWT } from 'jose';
+import { verifyToken } from '../../../packages/cloudflare-workers/src/auth.js';
+import {
+  createDelegationRoute,
+} from '../../../packages/cloudflare-workers/src/tap-delegation-routes.js';
+import {
+  getReputationRoute,
+} from '../../../packages/cloudflare-workers/src/tap-reputation-routes.js';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../packages/cloudflare-workers/src/tap-auth-helpers.js', () => ({
+  validateTAPAppAccess: vi.fn(),
+}));
+
+import { validateTAPAppAccess } from '../../../packages/cloudflare-workers/src/tap-auth-helpers.js';
+const mockValidateTAPAppAccess = validateTAPAppAccess as ReturnType<typeof vi.fn>;
+
+vi.mock('../../../packages/cloudflare-workers/src/tap-delegation.js', () => ({
+  createDelegation: vi.fn(),
+}));
+
+import { createDelegation } from '../../../packages/cloudflare-workers/src/tap-delegation.js';
+const mockCreateDelegation = createDelegation as ReturnType<typeof vi.fn>;
+
+vi.mock('../../../packages/cloudflare-workers/src/tap-reputation.js', () => ({
+  getReputationScore: vi.fn(),
+}));
+
+import { getReputationScore } from '../../../packages/cloudflare-workers/src/tap-reputation.js';
+const mockGetReputationScore = getReputationScore as ReturnType<typeof vi.fn>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = 'test-secret-key-12345';
+const TEST_APP_ID = 'app_test123';
+const TEST_AGENT_ID = 'agent_abc123';
+
+class MockKV {
+  private store = new Map<string, string>();
+  async get(key: string) { return this.store.get(key) ?? null; }
+  async put(key: string, value: string) { this.store.set(key, value); }
+  async delete(key: string) { this.store.delete(key); }
+}
+
+async function makeAgentIdentityToken(agentId: string, appId: string) {
+  return new SignJWT({ type: 'botcha-agent-identity', agent_id: agentId, app_id: appId })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(agentId)
+    .setIssuer('botcha.ai')
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .setJti('jti-' + Math.random())
+    .sign(new TextEncoder().encode(SECRET));
+}
+
+function createMockContext(overrides: {
+  paramFn?: (key: string) => string | undefined;
+  body?: Record<string, any>;
+  agentsKV?: MockKV;
+  sessionsKV?: MockKV;
+} = {}) {
+  return {
+    req: {
+      json: vi.fn().mockResolvedValue(overrides.body ?? {}),
+      param: vi.fn().mockImplementation(overrides.paramFn ?? (() => undefined)),
+      header: vi.fn().mockReturnValue(undefined),
+      query: vi.fn().mockReturnValue(undefined),
+    },
+    json: vi.fn().mockImplementation((body: any, status?: number) =>
+      new Response(JSON.stringify(body), {
+        status: status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ),
+    env: {
+      AGENTS: overrides.agentsKV ?? new MockKV(),
+      SESSIONS: overrides.sessionsKV ?? new MockKV(),
+      JWT_SECRET: SECRET,
+    },
+  } as any;
+}
+
+// ─── Bug 1: GET /v1/agents/me — agent-identity token acceptance ───────────────
+
+describe('Bug 1 fix: /v1/agents/me accepts agent-identity tokens', () => {
+  test('verifyToken with allowedTypes accepts botcha-agent-identity', async () => {
+    const token = await makeAgentIdentityToken(TEST_AGENT_ID, TEST_APP_ID);
+    const result = await verifyToken(token, SECRET, undefined, {
+      allowedTypes: ['botcha-verified', 'botcha-agent-identity'],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.payload?.type).toBe('botcha-agent-identity');
+    expect(result.payload?.agent_id).toBe(TEST_AGENT_ID);
+  });
+
+  test('verifyToken WITHOUT allowedTypes REJECTS botcha-agent-identity (regression guard)', async () => {
+    const token = await makeAgentIdentityToken(TEST_AGENT_ID, TEST_APP_ID);
+    // Default (undefined options) only allows botcha-verified — agent-identity must be explicitly allowed
+    const result = await verifyToken(token, SECRET, undefined, undefined);
+    expect(result.valid).toBe(false);
+  });
+
+  test('the agents/me fix uses allowedTypes — agent_id is extractable from token', async () => {
+    const token = await makeAgentIdentityToken(TEST_AGENT_ID, TEST_APP_ID);
+    const result = await verifyToken(token, SECRET, undefined, {
+      allowedTypes: ['botcha-verified', 'botcha-agent-identity'],
+    });
+    // The me route uses result.payload?.agent_id to look up the agent
+    expect(result.payload?.agent_id).toBe(TEST_AGENT_ID);
+  });
+});
+
+// ─── Bug 2: GET /v1/agents/:id/reputation alias route ────────────────────────
+
+describe('Bug 2 fix: getReputationRoute reads both :agent_id and :id params', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateTAPAppAccess.mockResolvedValue({
+      valid: true,
+      appId: TEST_APP_ID,
+    });
+    mockGetReputationScore.mockResolvedValue({
+      success: true,
+      score: {
+        agent_id: TEST_AGENT_ID,
+        app_id: TEST_APP_ID,
+        score: 500,
+        tier: 'neutral',
+        event_count: 0,
+        positive_events: 0,
+        negative_events: 0,
+        last_event_at: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        category_scores: {},
+      },
+    });
+  });
+
+  test('works with :agent_id param (primary route /v1/reputation/:agent_id)', async () => {
+    const ctx = createMockContext({
+      paramFn: (key) => (key === 'agent_id' ? TEST_AGENT_ID : undefined),
+    });
+    const response = await getReputationRoute(ctx);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.agent_id).toBe(TEST_AGENT_ID);
+  });
+
+  test('works with :id param (alias route /v1/agents/:id/reputation)', async () => {
+    const ctx = createMockContext({
+      // The alias route provides :id, NOT :agent_id
+      paramFn: (key) => (key === 'id' ? TEST_AGENT_ID : undefined),
+    });
+    const response = await getReputationRoute(ctx);
+    const data = await response.json();
+    // Before fix: data.success === false, error === 'MISSING_AGENT_ID'
+    // After fix: resolves correctly
+    expect(data.success).toBe(true);
+    expect(data.agent_id).toBe(TEST_AGENT_ID);
+  });
+
+  test('returns MISSING_AGENT_ID when neither param is present', async () => {
+    const ctx = createMockContext({
+      paramFn: () => undefined,
+    });
+    const response = await getReputationRoute(ctx);
+    const data = await response.json();
+    expect(data.success).toBe(false);
+    expect(data.error).toBe('MISSING_AGENT_ID');
+  });
+});
+
+// ─── Bug 3: POST /v1/delegations — string capability normalization ────────────
+
+describe('Bug 3 fix: delegation accepts string capabilities like ["browse", "search"]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateTAPAppAccess.mockResolvedValue({
+      valid: true,
+      appId: TEST_APP_ID,
+    });
+  });
+
+  test('rejects missing capabilities with MISSING_CAPABILITIES', async () => {
+    const ctx = createMockContext({
+      body: { grantor_id: TEST_AGENT_ID, grantee_id: 'agent_other' },
+    });
+    const response = await createDelegationRoute(ctx);
+    const data = await response.json();
+    expect(data.success).toBe(false);
+    expect(data.error).toBe('MISSING_CAPABILITIES');
+  });
+
+  test('normalizes string capabilities to objects before validation', async () => {
+    mockCreateDelegation.mockResolvedValue({
+      success: true,
+      delegation: {
+        delegation_id: 'del_abc',
+        grantor_id: TEST_AGENT_ID,
+        grantee_id: 'agent_other',
+        capabilities: [{ action: 'browse' }, { action: 'search' }],
+        depth: 1,
+        created_at: Date.now(),
+        expires_at: Date.now() + 3600000,
+        revoked: false,
+      },
+    });
+
+    const ctx = createMockContext({
+      body: {
+        grantor_id: TEST_AGENT_ID,
+        grantee_id: 'agent_other',
+        capabilities: ['browse', 'search'], // ← plain strings, not objects
+      },
+    });
+    const response = await createDelegationRoute(ctx);
+    const data = await response.json();
+
+    // Before fix: INVALID_CAPABILITY with confusing message
+    // After fix: normalization converts to [{action:'browse'}, {action:'search'}] and proceeds
+    expect(data.error).not.toBe('INVALID_CAPABILITY');
+
+    // createDelegation should have been called with normalized objects
+    expect(mockCreateDelegation).toHaveBeenCalled();
+    const callOptions = mockCreateDelegation.mock.calls[0][3]; // 4th arg is options
+    expect(callOptions.capabilities).toEqual([{ action: 'browse' }, { action: 'search' }]);
+  });
+
+  test('rejects truly invalid capability action with clear error', async () => {
+    const ctx = createMockContext({
+      body: {
+        grantor_id: TEST_AGENT_ID,
+        grantee_id: 'agent_other',
+        capabilities: ['fly', 'teleport'], // not valid TAP actions
+      },
+    });
+    const response = await createDelegationRoute(ctx);
+    const data = await response.json();
+    expect(data.success).toBe(false);
+    expect(data.error).toBe('INVALID_CAPABILITY');
+    // Error message should name the bad action AND clarify accepted formats
+    expect(data.message).toContain('fly');
+    expect(data.message).toContain('{\"action\"');
+  });
+
+  test('still accepts object-format capabilities (no regression)', async () => {
+    mockCreateDelegation.mockResolvedValue({
+      success: true,
+      delegation: {
+        delegation_id: 'del_xyz',
+        grantor_id: TEST_AGENT_ID,
+        grantee_id: 'agent_other',
+        capabilities: [{ action: 'browse' }],
+        depth: 1,
+        created_at: Date.now(),
+        expires_at: Date.now() + 3600000,
+        revoked: false,
+      },
+    });
+
+    const ctx = createMockContext({
+      body: {
+        grantor_id: TEST_AGENT_ID,
+        grantee_id: 'agent_other',
+        capabilities: [{ action: 'browse' }], // ← object format, existing style
+      },
+    });
+    const response = await createDelegationRoute(ctx);
+    const data = await response.json();
+    expect(data.error).not.toBe('INVALID_CAPABILITY');
+    expect(mockCreateDelegation).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/auth/token-validate-all-types.test.ts
+++ b/tests/unit/auth/token-validate-all-types.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression tests for POST /v1/token/validate accepting all BOTCHA token types.
+ *
+ * Bug: The public /v1/token/validate endpoint called verifyToken with undefined options,
+ * defaulting allowedTypes to ['botcha-verified']. This caused all non-challenge tokens
+ * (agent-identity, attestation, ans-badge, vc) to fail with "Invalid token type".
+ *
+ * Fix: Pass { allowedTypes: [...ALL_BOTCHA_ACCESS_TOKEN_TYPES] } so any valid
+ * BOTCHA access token can be validated via the public endpoint.
+ *
+ * Intentional exclusion: botcha-refresh tokens are bearer credentials and must
+ * NOT be validated by third parties (they authenticate the agent, not the action).
+ */
+
+import { describe, test, expect } from 'vitest';
+import { SignJWT } from 'jose';
+import {
+  verifyToken,
+  ALL_BOTCHA_ACCESS_TOKEN_TYPES,
+} from '../../../packages/cloudflare-workers/src/auth.js';
+
+const TEST_SECRET = 'test-secret-for-token-validate-tests-32bytes!!';
+
+/** Sign a minimal HS256 JWT with the given type. */
+async function signToken(type: string, extra?: Record<string, unknown>): Promise<string> {
+  return new SignJWT({
+    type,
+    jti: crypto.randomUUID(),
+    sub: 'test-subject',
+    ...extra,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(new TextEncoder().encode(TEST_SECRET));
+}
+
+// ─── ALL_BOTCHA_ACCESS_TOKEN_TYPES constant ───────────────────────────────────
+
+describe('ALL_BOTCHA_ACCESS_TOKEN_TYPES', () => {
+  test('includes botcha-verified', () => {
+    expect(ALL_BOTCHA_ACCESS_TOKEN_TYPES).toContain('botcha-verified');
+  });
+
+  test('includes botcha-agent-identity', () => {
+    expect(ALL_BOTCHA_ACCESS_TOKEN_TYPES).toContain('botcha-agent-identity');
+  });
+
+  test('includes botcha-attestation', () => {
+    expect(ALL_BOTCHA_ACCESS_TOKEN_TYPES).toContain('botcha-attestation');
+  });
+
+  test('includes botcha-ans-badge', () => {
+    expect(ALL_BOTCHA_ACCESS_TOKEN_TYPES).toContain('botcha-ans-badge');
+  });
+
+  test('includes botcha-vc', () => {
+    expect(ALL_BOTCHA_ACCESS_TOKEN_TYPES).toContain('botcha-vc');
+  });
+
+  test('does NOT include botcha-refresh (refresh tokens are bearer credentials)', () => {
+    expect(ALL_BOTCHA_ACCESS_TOKEN_TYPES).not.toContain('botcha-refresh');
+  });
+});
+
+// ─── verifyToken with all allowed types (simulating /v1/token/validate fix) ──
+
+describe('verifyToken with ALL_BOTCHA_ACCESS_TOKEN_TYPES (POST /v1/token/validate behavior)', () => {
+  const opts = { allowedTypes: [...ALL_BOTCHA_ACCESS_TOKEN_TYPES] };
+
+  test('accepts botcha-verified token', async () => {
+    const token = await signToken('botcha-verified', { solveTime: 42 });
+    const result = await verifyToken(token, TEST_SECRET, undefined, opts);
+    expect(result.valid).toBe(true);
+    expect(result.payload?.type).toBe('botcha-verified');
+  });
+
+  test('accepts botcha-agent-identity token', async () => {
+    const token = await signToken('botcha-agent-identity', {
+      agent_id: 'agent_abc123',
+      app_id: 'app_xyz',
+    });
+    const result = await verifyToken(token, TEST_SECRET, undefined, opts);
+    expect(result.valid).toBe(true);
+    expect(result.payload?.type).toBe('botcha-agent-identity');
+  });
+
+  test('accepts botcha-attestation token', async () => {
+    const token = await signToken('botcha-attestation', {
+      can: ['browse:*'],
+      cannot: [],
+    });
+    const result = await verifyToken(token, TEST_SECRET, undefined, opts);
+    expect(result.valid).toBe(true);
+    expect(result.payload?.type).toBe('botcha-attestation');
+  });
+
+  test('accepts botcha-ans-badge token', async () => {
+    const token = await signToken('botcha-ans-badge', { name: 'my-agent.botcha' });
+    const result = await verifyToken(token, TEST_SECRET, undefined, opts);
+    expect(result.valid).toBe(true);
+    expect(result.payload?.type).toBe('botcha-ans-badge');
+  });
+
+  test('accepts botcha-vc token', async () => {
+    const token = await signToken('botcha-vc', { vc: { type: ['VerifiableCredential'] } });
+    const result = await verifyToken(token, TEST_SECRET, undefined, opts);
+    expect(result.valid).toBe(true);
+    expect(result.payload?.type).toBe('botcha-vc');
+  });
+
+  test('rejects botcha-refresh token (intentionally excluded)', async () => {
+    const token = await signToken('botcha-refresh', { solveTime: 42 });
+    const result = await verifyToken(token, TEST_SECRET, undefined, opts);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid token type');
+  });
+
+  test('rejects unknown token type', async () => {
+    const token = await signToken('botcha-unknown-type');
+    const result = await verifyToken(token, TEST_SECRET, undefined, opts);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid token type');
+  });
+});
+
+// ─── Regression: old behavior caused failures ─────────────────────────────────
+
+describe('Regression: old default allowedTypes = ["botcha-verified"] caused failures', () => {
+  test('OLD behavior: agent-identity token fails with default allowedTypes', async () => {
+    const token = await signToken('botcha-agent-identity', { agent_id: 'agent_abc' });
+    // Simulate old behavior: no allowedTypes option passed
+    const result = await verifyToken(token, TEST_SECRET);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid token type');
+  });
+
+  test('OLD behavior: attestation token fails with default allowedTypes', async () => {
+    const token = await signToken('botcha-attestation', { can: ['browse:*'] });
+    const result = await verifyToken(token, TEST_SECRET);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid token type');
+  });
+
+  test('NEW behavior: agent-identity token passes with ALL_BOTCHA_ACCESS_TOKEN_TYPES', async () => {
+    const token = await signToken('botcha-agent-identity', { agent_id: 'agent_abc' });
+    const result = await verifyToken(token, TEST_SECRET, undefined, {
+      allowedTypes: [...ALL_BOTCHA_ACCESS_TOKEN_TYPES],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test('NEW behavior: attestation token passes with ALL_BOTCHA_ACCESS_TOKEN_TYPES', async () => {
+    const token = await signToken('botcha-attestation', { can: ['browse:*'] });
+    const result = await verifyToken(token, TEST_SECRET, undefined, {
+      allowedTypes: [...ALL_BOTCHA_ACCESS_TOKEN_TYPES],
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/tests/unit/challenges/speed.test.ts
+++ b/tests/unit/challenges/speed.test.ts
@@ -19,12 +19,14 @@ describe('Speed Challenge', () => {
     });
 
     test('adjusts timeout based on RTT when client timestamp provided', () => {
-      const clientTimestamp = Date.now() - 100; // Simulate 100ms RTT
+      const clientTimestamp = Date.now() - 100; // Simulate ~100ms RTT
       const challenge = generateSpeedChallenge(clientTimestamp);
       
       expect(challenge.timeLimit).toBeGreaterThan(500); // Should be adjusted
       expect(challenge).toHaveProperty('rttInfo');
-      expect(challenge.rttInfo?.measuredRtt).toBe(100);
+      // measuredRtt should be ≥100ms — use range check because clock ticks during test execution
+      expect(challenge.rttInfo?.measuredRtt).toBeGreaterThanOrEqual(100);
+      expect(challenge.rttInfo?.measuredRtt).toBeLessThan(200); // sanity upper bound
       expect(challenge.rttInfo?.adjustedTimeout).toBeGreaterThan(500);
     });
 


### PR DESCRIPTION
## Summary

Four confirmed bugs found during weekly inspection sprint (2026-04-27).

---

### Bug 4 (new, this sprint): `POST /v1/token/validate` rejects non-challenge tokens

**Root cause:** Handler calls `verifyToken(token, secret, env, undefined, publicKey)` — `undefined` options defaults `allowedTypes` to `["botcha-verified"]` only.

**Impact:** Agents trying to verify a token they received (attestation, agent-identity, ANS badge, VC) get `{"valid": false, "error": "Invalid token type"}` from an endpoint documented as "verify **any** BOTCHA token."

**Fix:** Export `ALL_BOTCHA_ACCESS_TOKEN_TYPES` from `auth.ts` and pass it as `allowedTypes`. Refresh tokens intentionally excluded — they are bearer credentials, not access credentials.

---

### Bugs 1–3 (from 2026-04-20 sprint — branch created, no PR opened)

**Bug 1: `GET /v1/agents/me` rejects agent-identity tokens**
Same root cause as Bug 4: `verifyToken` called without `allowedTypes`, blocking OAuth refresh tokens on the one route specifically designed for agent self-identification.

**Bug 2: `GET /v1/agents/:id/reputation` → 400 MISSING_AGENT_ID**
Alias route uses `:id` param but `getReputationRoute` reads `c.req.param("agent_id")` — always undefined. Fix: try both param names.

**Bug 3: `POST /v1/delegations` — string capabilities give misleading error**
`["browse", "search"]` → "Invalid capability action. Valid: browse..." — wrong diagnosis (format issue, not value issue). Fix: normalize strings to `{action}` objects before validation; clearer error names the bad value and shows both accepted formats.

---

## Tests

+17 new tests (all pass):
- `ALL_BOTCHA_ACCESS_TOKEN_TYPES` constant coverage
- Each token type accepted by the fix
- Refresh token intentionally rejected
- Regression guards for old behavior

## Affected files

- `packages/cloudflare-workers/src/auth.ts` — `ALL_BOTCHA_ACCESS_TOKEN_TYPES` export
- `packages/cloudflare-workers/src/index.tsx` — `/v1/token/validate` fix + `agents/me` fix (from prev branch)
- `packages/cloudflare-workers/src/tap-delegation-routes.ts` — string caps normalization (from prev branch)
- `packages/cloudflare-workers/src/tap-reputation-routes.ts` — dual param read (from prev branch)
- `tests/unit/auth/token-validate-all-types.test.ts` — 17 new tests
- `tests/unit/agents/fix-ux-bugs-2026-04-20.test.ts` — 10 tests from prev branch
