### PR TITLE
fix: add missing app_secret to MCP docs for POST /v1/apps/:id/verify-email

### DIFF
--- a/packages/cloudflare-workers/src/mcp.ts
+++ b/packages/cloudflare-workers/src/mcp.ts
@@ -116,7 +116,7 @@ Revocation is KV-backed with fail-open on infrastructure errors.`,
 
 App lifecycle:
 1. POST /v1/apps {"email": "..."} → app_id + app_secret (save the secret!)
-2. POST /v1/apps/:id/verify-email {"code": "123456"} → enables recovery
+2. POST /v1/apps/:id/verify-email {"code": "123456", "app_secret": "sk_..."} → enables recovery
 3. Use app_id on all API calls via ?app_id=, X-App-Id header, or JWT claim`,
     endpoints: [
       'POST /v1/apps',


### PR DESCRIPTION
Closes #44 

## Summary

- The MCP knowledge base (`packages/cloudflare-workers/src/mcp.ts`, `apps` feature detail) documented the `POST /v1/apps/:id/verify-email` payload as `{"code": "123456"}`, omitting the required `app_secret` field.
- The actual route handler (`index.tsx:2288`) parses both `code` and `app_secret` from the body and passes the secret to `authorizeAppManagement` for authorization.
- All other references in the codebase (`index.tsx:360`, `index.tsx:809`, `static.ts:52`, `static.ts:430`, `static.ts:730`) consistently show the correct payload `{"code": "123456", "app_secret": "sk_..."}`.

## Test plan

- [ ] All existing tests pass (`bun run test:run` — 1207 tests, 43 files)
- [ ] MCP `get_feature("apps")` now returns the correct payload example
- [ ] MCP `search_docs("verify-email")` returns accurate documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)