### PR TITLE
fix: remove verification_code from POST /v1/apps response

### DIFF
--- a/packages/cloudflare-workers/src/index.tsx
+++ b/packages/cloudflare-workers/src/index.tsx
@@ -2222,12 +2222,11 @@ app.post('/v1/apps', async (c) => {
       email: result.email,
       email_verified: false,
       verification_required: true,
-      verification_code: result.verification_code,
-      warning: '⚠️ Save your app_secret now — it cannot be retrieved again! A verification code has also been sent to your email.',
+      warning: '⚠️ Save your app_secret now — it cannot be retrieved again! A verification code has been sent to your email.',
       credential_advice: 'Store the app_id and app_secret securely. Use persistent agent memory if available, or instruct your human to save them in a password manager (1Password, Bitwarden, etc). If lost, recovery is available via the verified email.',
       created_at: new Date().toISOString(),
       rate_limit: 100,
-      next_step: `POST /v1/apps/${result.app_id}/verify-email with { "code": "${result.verification_code}", "app_secret": "${result.app_secret}" }`,
+      next_step: `Check your email for a 6-digit verification code, then POST /v1/apps/${result.app_id}/verify-email with { "code": "<6-digit code from email>", "app_secret": "${result.app_secret}" }`,
     }, 201);
   } catch (error) {
     if (error instanceof EmailAlreadyRegisteredError) {


### PR DESCRIPTION
Fixes #47

## Summary

- Removed the `verification_code` field from the `POST /v1/apps` JSON response
- Rewrote the `next_step` hint to reference "the code from your email" instead of embedding the literal code

## Why

Returning the raw 6-digit code in the payload allowed any caller to skip email verification entirely — just read it from the response and call `/verify-email` without ever checking the inbox. This made email ownership unverifiable.

## What changed

`packages/cloudflare-workers/src/index.tsx` — the `POST /v1/apps` route handler:

```diff
-    verification_code: result.verification_code,
     warning: '⚠️ Save your app_secret now — it cannot be retrieved again! A verification code has been sent to your email.',
-    next_step: `POST /v1/apps/${result.app_id}/verify-email with { "code": "${result.verification_code}", "app_secret": "${result.app_secret}" }`,
+    next_step: `Check your email for a 6-digit verification code, then POST /v1/apps/${result.app_id}/verify-email with { "code": "<6-digit code from email>", "app_secret": "${result.app_secret}" }`,
```

`result.verification_code` is still used internally to compose the verification email — only the HTTP response serialisation changes.

## Test plan

- [x] All 1207 existing tests pass (`bun run test:run`)
- [ ] Register a new app and confirm the response no longer contains `verification_code`
- [ ] Confirm the verification email still arrives and the code in it successfully verifies the email via `POST /v1/apps/:id/verify-email`

🤖 Generated with [Claude Code](https://claude.com/claude-code)