### PR TITLE
fix: remove existing_app_id from 409 response + clarify recovery instructions

### DIFF
--- a/packages/cloudflare-workers/src/index.tsx
+++ b/packages/cloudflare-workers/src/index.tsx
@@ -2246,8 +2246,7 @@ app.post('/v1/apps', async (c) => {
         success: false,
         error: 'EMAIL_ALREADY_REGISTERED',
         message: `Email ${error.email} is already registered.`,
-        existing_app_id: error.existing_app_id,
-        recovery: `POST /v1/auth/recover with { "email": "${error.email}" } to recover your credentials.`,
+        recovery: `POST /v1/auth/recover with { "email": "${error.email}" } to receive a BOTCHA code by email. Your human can then visit https://botcha.ai, click "Account", and enter the code to retrieve their app_id and share it with you.`,
       }, 409);
     }
     return c.json({


### PR DESCRIPTION
Closes #50

## Summary

- Remove `existing_app_id` from the `EMAIL_ALREADY_REGISTERED` 409 response body — leaking it allows unauthenticated app_id enumeration by probing with arbitrary emails
- Update `recovery` message to accurately describe the human-mediated flow: call `POST /v1/auth/recover` → receive BOTCHA code by email → visit https://botcha.ai → click "Account" → enter code → retrieve `app_id` and share with the agent

## Test plan

- [ ] `POST /v1/apps` with a duplicate email returns 409 with no `existing_app_id` field
- [ ] `recovery` message in the 409 body matches the updated wording
- [ ] All existing tests pass (`bun run test:run` — 1219 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)