### PR TITLE
fix: add key_fingerprint to TAPAgent type (fixes CI)

### DIFF
--- a/packages/cloudflare-workers/src/tap-agents.ts
+++ b/packages/cloudflare-workers/src/tap-agents.ts
@@ -19,6 +19,7 @@ import { Agent, KVNamespace, generateAgentId } from './agents.js';
 export interface TAPAgent extends Agent {
   // Cryptographic identity (optional for backward compatibility)
   public_key?: string;           // PEM-encoded public key
+  key_fingerprint?: string;      // SHA-256 fingerprint of the public key (derived, cached)
   signature_algorithm?: 'ecdsa-p256-sha256' | 'rsa-pss-sha256' | 'ed25519';
   key_created_at?: number;       // When the key was generated
   key_expires_at?: number;       // When the key expires (epoch ms)


### PR DESCRIPTION
## Problem

CI has been broken since May 11 with:
```
src/index.tsx(2889,15): error TS2339: Property 'key_fingerprint' does not exist on type 'TAPAgent'.
src/index.tsx(2890,40): error TS2339: Property 'key_fingerprint' does not exist on type 'TAPAgent'.
```

## Root Cause

`key_fingerprint` was being read from the `agent` object in the `GET /v1/agents/me` route (and agent lookup), but the field was never added to the `TAPAgent` interface in `tap-agents.ts`. The field exists in the DB and is already used in `tap-routes.ts` — just missing from the type.

## Fix

Added `key_fingerprint?: string` to the `TAPAgent` interface alongside the other cryptographic identity fields.

## Verified

`npm run build` passes cleanly locally.