### PR TITLE
fix: switch vitest environment from happy-dom to node

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'happy-dom',
+    environment: 'node',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Problem

9 test suites were failing with `Error: No such built-in module: node:` because vitest was running them in `happy-dom` environment, which does not support Node.js built-in modules like `crypto`.

## Root Cause

`vitest.config.ts` had `environment: happy-dom` as the default. BOTCHA is a backend/Cloudflare Workers library with zero DOM dependencies (confirmed by grep across all test files), so `happy-dom` was incorrect.

## Fix

One-line change: `happy-dom` → `node`. Node 22 includes all Web APIs (fetch, crypto.subtle, URL, TextEncoder, etc.) that happy-dom provided, so no existing tests break.

## Results

| | Before | After |
|---|---|---|
| Test suites | 39 ✅ / 9 ❌ | **48 ✅ / 0 ❌** |
| Tests | 1070 | **1286** (+216 previously untested) |