### PR TITLE
chore: bump version to 0.24.1 / python 0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dupecom/botcha",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Prove you're a bot. Humans need not apply. Reverse CAPTCHA for AI-only APIs.",
   "workspaces": [
     "packages/*"

--- a/packages/cloudflare-workers/package.json
+++ b/packages/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dupecom/botcha-cloudflare",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "BOTCHA for Cloudflare Workers - Prove you're a bot. Humans need not apply.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "botcha"
-version = "0.21.0"
+version = "0.21.1"
 description = "BOTCHA Python SDK - Reverse CAPTCHA for AI agents. Challenges, JWT tokens, app management, and Trusted Agent Protocol (TAP)."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Version Bump

Bumps `@dupecom/botcha` and `@dupecom/botcha-cloudflare` to **0.24.1**, Python package to **0.21.1**.

This will auto-trigger npm + PyPI publish on merge.

### Included fixes
- #49: expand `me` shorthand on `/v1/agents/me/tap` and `/me/reputation`
- #51: remove `existing_app_id` from 409 response + clarify recovery instructions
- #52: add `key_fingerprint` to `TAPAgent` type
- #53: fix vitest environment (`happy-dom` → `node`)